### PR TITLE
Bug fix for issue #68 and argument decrement for function in writeFile.js

### DIFF
--- a/src/generateArray.js
+++ b/src/generateArray.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 // const utils = require('@utils')
 const utils = require('./utils')
+const PATH = require('path')
 
 // const {
 //   users,
@@ -123,11 +124,14 @@ function getMeasurementSystem () {
 
 // @TODO this is a method from a project. maybe we should move it there, because it's confusing right now
 function getMeasurementUnits () {
-  var result = []
-  var measurementUnitsId = generateArrWithId(files.measurementUnits, 'id')
-  measurementUnitsId = generateArrWithId(files.measurementUnitsId, 'system_id')
+  const dirMeasurementUnits = PATH.parse(files.measurementUnits).dir
+  let measurementUnitsList = utils.readAllFiles(dirMeasurementUnits)[1]
+  let result = []
 
-  _.map(measurementUnitsId, unit => {
+  measurementUnitsList = generateArrWithId(measurementUnitsList, 'id')
+  measurementUnitsList = generateArrWithId(measurementUnitsList, 'system_id')
+
+  _.map(measurementUnitsList, unit => {
     result.push({
       'id': unit.id,
       'system_id': unit.system_id,
@@ -140,6 +144,7 @@ function getMeasurementUnits () {
       'error': 'null'
     })
   })
+
   return result
 }
 

--- a/src/generateFiles.js
+++ b/src/generateFiles.js
@@ -18,24 +18,23 @@ const { config, setupPath } = require('./configGenerator')
 function generateFiles (pathToSrc) {
     // console.log(config[0]["data"]())
     setupPath(pathToSrc)
-    
+
     config.map(settings => {
       var fileName = settings['name']
       var folder = fileName.charAt(0).toUpperCase() + fileName.slice(1)
       //   var path = './output/' + fileName + '.json';
       var folderPath = pathToSrc +'/data/' + folder
-  
+
       if (!fs.existsSync(folderPath)) { // @TODO use isDirectory?
         fs.mkdirSync(folderPath)
       }
       var path = folderPath + '/' + fileName + '.json'
       var data = settings['data']()
-      // console.log(data);
-  
+
       writeFile(path, data)
     })
-  
-  
+
+
 }
 
 // @TODO i don't think that later we should call this method inside of this file

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -206,11 +206,6 @@ function updateContent(content, keys) {
         }
     }
 
-    // content.forEach((obj) => {
-    //   obj.forEach((key) => {
-    //
-    //   })
-    // })
     return content
 }
 

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -67,10 +67,10 @@ function fixPath(path) {
  * */
 function readData(path, file) {
     console.log(path + file);
-    
+
     let data = fs.readFileSync(path + file)
     console.log(data);
-    
+
     let fileData = JSON.parse(data)
     return fileData
 }
@@ -104,33 +104,38 @@ function makeFolder(path, file) {
 }
 /**
  * For splitObject
- * @param {String} path
- * @param {String} file
+ *
+ * @describe split large files into single elements
+ *
+ * @param {String} fullPath
  * @param {var} flag
- * @param {var} callback
  * @param {var} keys
+ * @param {var} callback
  */
-function splitObject(path, file, flag = 1, callback, keys = []) { // split large files into single elements
-    /*
-        flag=1 ==> name according to index
-        flag=0 ==> name according to "name" attribute
-      */
-    if (file.slice(-5) !== '.json') {
-        console.log("Require .json file.")
-        return
-    }
+ function splitObject(fullPath, flag = 1,  keys = [], callback) {
+     /*
+       flag=1 ==> name according to index
+       flag=0 ==> name according to "name" attribute
+     */
+     const file = PATH.basename(fullPath)
+     let path = PATH.parse(fullPath).dir
+
+     if (PATH.extname(file) !== '.json') {
+         console.log("Require .json file.")
+         return
+     }
+
     path = fixPath(path)
     let fileData = readData(path, file) // Reading data...
     var folderNamePath = makeFolder(path, file) // new folder to save splitted files
     saveFile(folderNamePath, file, fileData, flag) // saving files
+
     if (callback instanceof Function) {
         setTimeout(function() {
             callback(folderNamePath, keys)
         }, 1000)
     }
-
-
-}
+ }
 // execute function
 // splitObject()
 
@@ -189,7 +194,9 @@ function combineObject(path, keys) {
  * @param {var} keys
  */
 function updateContent(content, keys) {
-    var len = content.length
+
+    const len = content.length
+
     for (var itr = 0; itr < len; itr++) {
         var elementLen = content[itr].length
         for (var i = 0; i < elementLen; i++) {
@@ -201,6 +208,7 @@ function updateContent(content, keys) {
     }
     return content
 }
+
 module.exports = {
     writeFile,
     test,

--- a/src/writeFile.js
+++ b/src/writeFile.js
@@ -10,8 +10,6 @@ const srcUtils = require('./../src/utils')
  * for makeReadable()
  * @param {Object} data a json object
  * */
-
-
 function makeReadable(data) {
     var dataStr = JSON.stringify(data)
     dataStr = dataStr.replace(/{"/g, '{ "')
@@ -21,6 +19,7 @@ function makeReadable(data) {
     dataStr = dataStr.replace(/,"/g, ',\n "')
     return dataStr
 }
+
 /**
  * Write in file
  * @param {String} path
@@ -206,6 +205,12 @@ function updateContent(content, keys) {
             }
         }
     }
+
+    // content.forEach((obj) => {
+    //   obj.forEach((key) => {
+    //
+    //   })
+    // })
     return content
 }
 


### PR DESCRIPTION
This is the bug fix of the command `npm run play` now it can generate `measurementUnits.json` with the id and system_id. This is for [issue #68](https://github.com/GroceriStar/food-static-files-generator/issues/68)

The second change is to the file `src/writeFile.js` in the function `splitObject()` Number of parameters have been decreased to 4. Instead of parameters file and path, now the parameter is fullPath which contains the file name. They are separated in the function. This is for [issue #48](https://github.com/GroceriStar/food-static-files-generator/issues/48) 