### PR TITLE
add debugging generator

### DIFF
--- a/debug/runGenerator.js
+++ b/debug/runGenerator.js
@@ -1,0 +1,11 @@
+const  { generateFiles } = require('../dist/index.cjs')
+
+const path = require('path')
+// module sd and food-static-files-generator should be in one folder
+// js
+// |- sd
+// |- food-static-files-generator
+const path1 = path.join(__dirname, '../../sd/src') 
+
+console.log(path1);
+generateFiles(path1)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "code-fix": "standard --fix",
     "format": "prettier",
     "play": "node ./src/play/play.js",
-    "buildBabel": "babel src -d dist"
+    "buildBabel": "babel src -d dist",
+    "debug:generator": "rollup -c && node ./debug/runGenerator.js"
+
   },
   "description": "module to use static JSON files with groceristar projects",
   "main": "dist/index.cjs",


### PR DESCRIPTION
This allows debugging generator. Execute this command
```
npm run debug:generator
```
Rollup will build index.cjs in dist folder. Then in runGenerator.js happens calling function generateFiles() 