### PR TITLE
update fileSystem tests

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -27,7 +27,7 @@ module.exports = {
     //   'eslint --fix',
     //   'prettier --write',
     //   'jest --findRelatedTests',
-    'npm run code-fix',
+    'npm run lint',
     'git add'
   ]
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,33 @@
+// {
+//   "*.js": ["eslint --fix", "git add"]
+// }
+// module.exports = {
+//   linters: {
+//     '**/*.+(js|md|ts|css|sass|less|graphql|yml|yaml|scss|json|vue)': [
+//       'eslint --fix',
+//       'prettier --write',
+//       'jest --findRelatedTests',
+//       'git add',
+//     ],
+//   },
+// };
+
+// Custom Ignore
+// const micromatch = require('micromatch')
+// module.exports = {
+//   '*.js': files => {
+//     // from `files` filter those _NOT_ matching `*test.js`
+//     const match = micromatch.not(files, '*test.js')
+//     return match.map(file => `eslint ${file}`)
+//   }
+// }
+
+module.exports = {
+  '**/*.+(js|json)': [
+    //   'eslint --fix',
+    //   'prettier --write',
+    //   'jest --findRelatedTests',
+    'npm run code-fix',
+    'git add'
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test:watch": "jest --watch",
     "test:cover": "jest --coverage",
     "lint": "eslint ./src --fix",
-    "code-fix": "eslint --fix",
     "format": "prettier",
     "play": "node ./src/play/play.js",
     "build:babel": "babel src -d dist",
@@ -71,6 +70,13 @@
     "path-exists": "^4.0.0",
     "randombytes": "^2.1.0",
     "uuid": "^3.3.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run clean",
+      "after": "lint-staged",
+      "then": "yarn precommit"
+    }
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@groceristar/static-data-generator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "scripts": {
     "bundle": "rollup -c",

--- a/src/configGenerator.js
+++ b/src/configGenerator.js
@@ -18,4 +18,4 @@ const config = [
   },
 ];
 
-export default config
+export default config;

--- a/src/fileSystem.js
+++ b/src/fileSystem.js
@@ -8,20 +8,25 @@ import { isDirectory } from './utils';
  * @param {Object} data
  * @param {Function} callback
  */
-const write = (path, data, callback) => {
-  const dataStr = stripSymbols(data);
-  // dataStr = '[' + dataStr + ']'
-  // console.log(dataStr)
+const write = (path, data) => {
 
-  writeFile(path, dataStr, (err) => {
-    if (err) {
-      console.log(err);
-      callback(false);
-    }
+  return new Promise(resolve => {
+    const dataStr = stripSymbols(data);
+    // dataStr = '[' + dataStr + ']'
+    // console.log(dataStr)
+  
+    writeFile(path, dataStr, (err) => {
+      if (err) {
+        console.log(err);
+        resolve(false);
+      } else {
+        console.info(`${path} file generated successfully!`);
+        resolve(true);
+      }
+    });
+  })
 
-    console.info(`${path} file generated successfully!`);
-    callback(true);
-  });
+  
 };
 
 /**
@@ -51,17 +56,22 @@ const read = (absolutePath) => {
  * */
 // @TODO save got 5 attributes and most of them are about directory/files...
 // there should be another way
-const save = (folderNamePath, file, fileData, flag, callback) => {
-  const fileDataLength = fileData.length;
-  for (let i = 0; i < fileDataLength; i++) {
-    // @TODO long line, I have feeling that it can be improved
-    // - we just need to find a better way to rewrite a getFileName method
-    const fileName = getFileName(file, fileData[i], flag, i);
-    const elementPath = `${folderNamePath}/${fileName}`;
-    write(elementPath, fileData[i], (status) => {
-      callback(status);
-    });
-  }
+const save = (folderNamePath, file, fileData, flag) => {
+  
+  return new Promise(async resolve => {
+    const fileDataLength = fileData.length;
+
+    for (let i = 0; i < fileDataLength; i++) {
+      // @TODO long line, I have feeling that it can be improved
+      // - we just need to find a better way to rewrite a getFileName method
+      const fileName = getFileName(file, fileData[i], flag, i);
+      const elementPath = `${folderNamePath}/${fileName}`;
+      const success = await write(elementPath, fileData[i]);
+      if(!success)
+        resolve(false)
+    }
+    resolve(true);
+  });
 };
 
 /**

--- a/src/fileSystem.js
+++ b/src/fileSystem.js
@@ -67,8 +67,11 @@ const save = (folderNamePath, file, fileData, flag) => {
       const fileName = getFileName(file, fileData[i], flag, i);
       const elementPath = `${folderNamePath}/${fileName}`;
       const success = await write(elementPath, fileData[i]);
-      if(!success)
+      if(!success){
         resolve(false)
+        //@TODO should we add here some console.info that might show us that we have an issue?
+      }
+        
     }
     resolve(true);
   });

--- a/src/fileSystem.js
+++ b/src/fileSystem.js
@@ -9,7 +9,6 @@ import { isDirectory } from './utils';
  * @param {Function} callback
  */
 const write = (path, data, callback) => {
-
   const dataStr = stripSymbols(data);
   // dataStr = '[' + dataStr + ']'
   // console.log(dataStr)
@@ -59,7 +58,7 @@ const save = (folderNamePath, file, fileData, flag, callback) => {
     // - we just need to find a better way to rewrite a getFileName method
     const fileName = getFileName(file, fileData[i], flag, i);
     const elementPath = `${folderNamePath}/${fileName}`;
-    write(elementPath, fileData[i], status => {
+    write(elementPath, fileData[i], (status) => {
       callback(status);
     });
   }
@@ -78,11 +77,11 @@ const makeFolder = (path, file) => {
     mkdirSync(folderNamePath);
   }
   return folderNamePath;
-}
+};
 
 export {
   write,
   read,
   save,
-  makeFolder
-}
+  makeFolder,
+};

--- a/src/generateFiles.js
+++ b/src/generateFiles.js
@@ -19,20 +19,20 @@ const generateFiles = (pathToSrc) => {
   config.map((settings) => {
     const { fileName, data } = settings;
     // console.log('3');
-      const uppercaseFileName = fileName.charAt(0).toUpperCase();
+    const uppercaseFileName = fileName.charAt(0).toUpperCase();
 
-      const folder = uppercaseFileName.concat(fileName.slice(1));
+    const folder = uppercaseFileName.concat(fileName.slice(1));
     //   var path = './output/' + fileName + '.json';
-      const folderPath = `${pathToSrc}/data/${folder}`;
+    const folderPath = `${pathToSrc}/data/${folder}`;
 
-      if (isDirectory(folderPath)) {
-        mkdirSync(folderPath);
-      }
+    if (isDirectory(folderPath)) {
+      mkdirSync(folderPath);
+    }
 
-      path = `${folderPath}/${fileName}.json`;
+    path = `${folderPath}/${fileName}.json`;
     //   console.log('4');
-      write(path, data());
+    write(path, data());
   });
 };
 
-export default generateFiles
+export default generateFiles;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @TODO I think we should make our module more accessible to our methods from the outside.
 
-import  generateFiles from './generateFiles'
+import generateFiles from './generateFiles';
 
 
 import {
@@ -10,8 +10,8 @@ import {
 
 import {
   read,
-  write
-} from './fileSystem'
+  write,
+} from './fileSystem';
 
 
 export {
@@ -19,5 +19,5 @@ export {
   combine,
   split,
   write,
-  read
-}
+  read,
+};

--- a/src/measurements.js
+++ b/src/measurements.js
@@ -1,12 +1,12 @@
 // trying to separate code from generate Array.
 // but we'll move them out soon.
 // @TODO can we replace it with alias?
+import { parse } from 'path';
+import _ from 'lodash';
 import { readAllFiles, generateArrWithId } from './utils';
 import setupPath from './generateArray';
 // const utils = require('./utils');
 // import utils from ('./utils')
-import { parse } from 'path';
-import _ from 'lodash';
 // Without files it wouldn't work without files... - Answer yes, I will fix it PS. Vadim :)
 // var files = '';
 
@@ -29,32 +29,32 @@ const getMeasurementSystem = () => {
     });
   });
   return result;
-}
+};
 
 const getMeasurementUnits = () => {
-    const files = setupPath('../../sd/data');
-    const dirMeasurementUnits = parse(files.measurementUnits).dir;
-    const result = [];
+  const files = setupPath('../../sd/data');
+  const dirMeasurementUnits = parse(files.measurementUnits).dir;
+  const result = [];
 
-    let measurementUnitsList = readAllFiles(dirMeasurementUnits)[1];
+  let measurementUnitsList = readAllFiles(dirMeasurementUnits)[1];
 
-    measurementUnitsList = generateArrWithId(measurementUnitsList, 'id');
-    measurementUnitsList = generateArrWithId(measurementUnitsList, 'system_id');
-    _.map(measurementUnitsList, (unit) => {
-      result.push({
-        id: unit.id,
-        system_id: unit.system_id,
-        type: unit.type,
-        name: unit.name,
-        singular: unit.singular,
-        plural: unit.plural,
-        short: unit.short,
-        pattern: unit.pattern,
-        error: 'null',
-      });
+  measurementUnitsList = generateArrWithId(measurementUnitsList, 'id');
+  measurementUnitsList = generateArrWithId(measurementUnitsList, 'system_id');
+  _.map(measurementUnitsList, (unit) => {
+    result.push({
+      id: unit.id,
+      system_id: unit.system_id,
+      type: unit.type,
+      name: unit.name,
+      singular: unit.singular,
+      plural: unit.plural,
+      short: unit.short,
+      pattern: unit.pattern,
+      error: 'null',
     });
-    return result;
-}
+  });
+  return result;
+};
 
 export {
   // setupPathMeasurements,

--- a/src/objects.js
+++ b/src/objects.js
@@ -2,9 +2,11 @@
 // as we did it at other files
 import { basename, parse, extname } from 'path';
 import { fixPath, readAllFiles } from './utils';
-import { read } from './fileSystem';
+import {
+  read, write, save, makeFolder,
+} from './fileSystem';
 import { updateContent } from './writeFile';
-import { write, save, makeFolder } from './fileSystem'
+
 
 /**
  * For combine()
@@ -53,7 +55,7 @@ function split(fullPath, flag = 1, keys = [], callback) {
   path = fixPath(path);
 
   // Reading data...
-  const absolutePath = path+file;
+  const absolutePath = path + file;
   const fileData = read(absolutePath);
   // new folder to save splitted files
   const folderNamePath = makeFolder(path, file);
@@ -67,7 +69,7 @@ function split(fullPath, flag = 1, keys = [], callback) {
   }
 }
 
-export  {
+export {
   combine,
   split,
 };

--- a/src/testsMethods.js
+++ b/src/testsMethods.js
@@ -18,7 +18,7 @@ const jsonSchemaTest = (file, example, schema) => {
 };
 
 
-export  {
+export {
   jsonFileNotEmptyTest,
   jsonSchemaTest,
 };

--- a/tests/fileSystem.test.js
+++ b/tests/fileSystem.test.js
@@ -1,17 +1,19 @@
 import { write, save, makeFolder } from '../src/fileSystem';
 
 describe('testing fileSystem()', () => {
-  test('testing function write()', () => {
+  test('testing function write()', done => {
     write('./output/test.json', [{
       'name': 'Test'
     }], status => {
       expect(status).toBe(true);
+      done();
     });
   });
 
-  test('testing function save()', () => {
+  test('testing function save()', done => {
     save('./output/', 'test.json', "[{'name':'Test'}]", false, status => {
       expect(status).toBe(true);
+      done();
     });
   });
 

--- a/tests/fileSystem.test.js
+++ b/tests/fileSystem.test.js
@@ -1,22 +1,21 @@
 import { write, save, makeFolder } from '../src/fileSystem';
 
 describe('testing fileSystem()', () => {
-  test('testing function write()', done => {
-    write('./output/test.json', [{
+  // test write()
+  test('testing function write()', async () => {
+    const result =  await write('./output/test.json', [{
       'name': 'Test'
-    }], status => {
-      expect(status).toBe(true);
-      done();
-    });
+    }]);
+    expect(result).toBe(true);
   });
 
-  test('testing function save()', done => {
-    save('./output/', 'test.json', "[{'name':'Test'}]", false, status => {
-      expect(status).toBe(true);
-      done();
-    });
+  // test save()
+  test('testing function save()', async () => {
+    const result = await save('./output/', 'test.json', "[{'name':'Test'}]", false);
+    expect(result).toBe(true);
   });
 
+  // test makeFolder()
   test('testing makeFolder()', () => {
     const result = makeFolder('./output/', 'test.json');
     expect(result).toBe('./output/test_elements');


### PR DESCRIPTION
This is a work in progress for issue #144 .
Is there any way to find where the `readData()` function in `src/fileSystem.js` is getting called. The logs inside this function are causing the tests to fail. This function was never called.tested in the tests.
A portion of error log on running `yarn test`:
```
Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "./output//undefined.json file generated successfully!".

      28 | /**
      29 |  * readData()
    > 30 |  * @param {string} absolutePath
         |             ^
      31 |  *
      32 |  */
      33 | const readData = (absolutePath) => {

      at CustomConsole.info (node_modules/@jest/console/build/CustomConsole.js:179:10)
      at src/fileSystem.js:30:13
      at node_modules/graceful-fs/graceful-fs.js:45:10
```